### PR TITLE
Replace references to /bin/bash with /usr/bin/env bash

### DIFF
--- a/backend/src/rvbbit_backend/core.clj
+++ b/backend/src/rvbbit_backend/core.clj
@@ -654,7 +654,7 @@
   ;; (println " ")
   ;; (wss/fig-render "Curiouser and curiouser!" :pink)
 
-   (shell/sh "/bin/bash" "-c" (str "rm -rf " "live/*"))
+   (shell/sh "/usr/bin/env" "bash" "-c" (str "rm -rf " "live/*"))
 
    (qp/create-slot-queue-system)
    (fpop/thaw-flow-results)
@@ -1108,13 +1108,13 @@
                             (ut/zprint-file "./defs/signals.edn" {:style [:justified-original] :parse-string? true :comment {:count? nil :wrap? nil} :width 120 :map {:comma? false :sort? false}})
                             (ut/zprint-file "./defs/solvers.edn" {:style [:justified-original] :parse-string? true :comment {:count? nil :wrap? nil} :width 120 :map {:comma? false :sort? false}})
                            ;(ut/ppa [:clearing-cache-db])
-                           ;(shell/sh "/bin/bash" "-c" (str "rm " "db/cache.db"))
-                            (shell/sh "/bin/bash" "-c" (str "rm " "flow-logs/*"))
-                            (shell/sh "/bin/bash" "-c" (str "rm " "reaction-logs/*"))
-                           ;(shell/sh "/bin/bash" "-c" (str "rm " "status-change-logs/*"))
-                            (shell/sh "/bin/bash" "-c" (str "rm " "tracker-logs/*"))
-                            (shell/sh "/bin/bash" "-c" (str "rm " "reaction-logs/*"))
-                           ;(shell/sh "/bin/bash" "-c" (str "rm " "db/system.db"))
+                           ;(shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "db/cache.db"))
+                            (shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "flow-logs/*"))
+                            (shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "reaction-logs/*"))
+                           ;(shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "status-change-logs/*"))
+                            (shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "tracker-logs/*"))
+                            (shell/sh "/usr/bin/env" "bash"  "-c" (str "rm " "reaction-logs/*"))
+                           ;(shell/sh "/usr/bin/env" "bash" "-c" (str "rm " "db/system.db"))
                             ))
 
    (ppy/add-watch+

--- a/backend/src/rvbbit_backend/websockets.clj
+++ b/backend/src/rvbbit_backend/websockets.clj
@@ -1248,7 +1248,7 @@
   [command]
   (let [;;shell                    (or (System/getenv "SHELL") "/bin/sh")
         ;;output                   (shell/sh shell "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
-        output                   (shell/sh "/bin/bash" "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
+        output                   (shell/sh "/usr/bin/env" "bash" "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
         split-lines              (vec (remove empty? (cstr/split-lines (get output :out))))
         exit-code                (get output :exit)
         error                    (vec (remove empty? (cstr/split-lines (get output :err))))
@@ -7441,7 +7441,7 @@
   [command]
   (let [;;shell                    (or (System/getenv "SHELL") "/bin/sh")
         ;;output                   (shell/sh shell "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
-        output                   (shell/sh "/bin/bash" "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
+        output                   (shell/sh "/usr/bin/env" "bash" "-c" (str "mkdir -p shell-root ; cd shell-root ; " command))
         split-lines              (vec (remove empty? (cstr/split-lines (get output :out))))
         exit-code                (get output :exit)
         error                    (vec (remove empty? (cstr/split-lines (get output :err))))

--- a/compile_all.sh
+++ b/compile_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if the current directory path ends with "rvbbit"
 if [[ "${PWD}" != */rvbbit ]]; then

--- a/zprint-config.sh
+++ b/zprint-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIRECTORY="backend/defs"
 

--- a/zprint-flows.sh
+++ b/zprint-flows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIRECTORY="backend/flows"
 

--- a/zprint-screens.sh
+++ b/zprint-screens.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIRECTORY="backend/screens"
 


### PR DESCRIPTION
/bin/bash is not available on all distros. (eg. NixOS)